### PR TITLE
fix: Update Span's == argument types to Self

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -74,7 +74,7 @@ public extension Span {
         hasher.combine(context.spanId)
     }
 
-    static func == (lhs: Span, rhs: Span) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.context.spanId == rhs.context.spanId
     }
 }


### PR DESCRIPTION
Resolves a compilation failure with recent Swift nightly toolchains.

```
./open-telemetry-swift/Sources/OpenTelemetryApi/Trace/Span.swift:77:17: error: member operator '==' of protocol 'Span' must have at least one argument of type 'Self'
 75 |     }
 76 | 
 77 |     static func == (lhs: Span, rhs: Span) -> Bool {
    |                 `- error: member operator '==' of protocol 'Span' must have at least one argument of type 'Self'
 78 |         return lhs.context.spanId == rhs.context.spanId
 79 |     }
```

To verify this change, install and build with a recent Swift nightly toolchain (I reproduced the failure with 2024-05-14 specifically).